### PR TITLE
feat: add `toConfig`

### DIFF
--- a/lib/Chainable.js
+++ b/lib/Chainable.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const withIs = require('class-is');
+
 class Chainable {
     constructor(parent) {
         this.parent = parent;
@@ -24,6 +26,10 @@ class Chainable {
 
         return this;
     }
+
+    toConfig() {
+        throw new Error('Not implemented');
+    }
 }
 
-module.exports = Chainable;
+module.exports = withIs(Chainable, { className: 'Chainable', symbolName: 'moxy/chained-config/Chainable' });

--- a/lib/ChainedMap.js
+++ b/lib/ChainedMap.js
@@ -1,16 +1,32 @@
 'use strict';
 
 const merge = require('deepmerge');
+const wrap = require('lodash.wrap');
 const Chainable = require('./Chainable');
 
 class ChainedMap extends Chainable {
-    constructor(parent) {
+    constructor(parent, options) {
         super(parent);
+
         this.store = new Map();
+
+        if (options && options.asArray) {
+            this.toConfig = wrap(this.toConfig.bind(this),
+                (toConfig, ...args) => Object.values(toConfig(...args)));
+        }
     }
 
     set(key, value) {
         this.store.set(key, value);
+
+        if (Chainable.isChainable(value) && this[key] !== value) {
+            Object.defineProperty(this, key, {
+                get: () => this.get(key),
+                set: (value) => this.set(key, value),
+                enumerable: true,
+                configurable: true,
+            });
+        }
 
         return this;
     }
@@ -42,11 +58,7 @@ class ChainedMap extends Chainable {
     }
 
     entries() {
-        return this.keys().reduce((entries, key) => {
-            entries[key] = this.get(key);
-
-            return entries;
-        }, {});
+        return [...this.store.entries()];
     }
 
     keys() {
@@ -85,13 +97,22 @@ class ChainedMap extends Chainable {
         return this;
     }
 
-    extend(methods) {
-        this.shorthands = methods;
-        methods.forEach((method) => {
-            this[method] = (value) => this.set(method, value);
+    shorthands(keys) {
+        keys.forEach((key) => {
+            this[key] = (value) => this.set(key, value);
         });
 
         return this;
+    }
+
+    toConfig() {
+        return this.entries().reduce((config, [key, value]) => {
+            value = Chainable.isChainable(value) ? value.toConfig() : value;
+
+            config[key] = value;
+
+            return config;
+        }, {});
     }
 }
 

--- a/lib/ChainedSet.js
+++ b/lib/ChainedSet.js
@@ -5,6 +5,7 @@ const Chainable = require('./Chainable');
 class ChainedSet extends Chainable {
     constructor(parent) {
         super(parent);
+
         this.store = new Set();
     }
 
@@ -52,6 +53,11 @@ class ChainedSet extends Chainable {
         this.store = new Set([...this.store, ...arr]);
 
         return this;
+    }
+
+    toConfig() {
+        return this.values()
+        .map((value) => Chainable.isChainable(value) ? value.toConfig() : value);
     }
 }
 

--- a/lib/OrderableChainedMap.js
+++ b/lib/OrderableChainedMap.js
@@ -4,8 +4,9 @@ const ChainedMap = require('./ChainedMap');
 const Chainable = require('./Chainable');
 
 class OrderableChainedMap extends ChainedMap {
-    constructor(parent) {
-        super(parent);
+    constructor(parent, options) {
+        super(parent, options);
+
         this.orderStore = new Map();
     }
 
@@ -24,11 +25,7 @@ class OrderableChainedMap extends ChainedMap {
     entries() {
         const keys = getOrderedKeys(this);
 
-        return keys.reduce((entries, key) => {
-            entries[key] = this.get(key);
-
-            return entries;
-        }, {});
+        return keys.map((key) => [key, this.get(key)]);
     }
 
     keys() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "is-regular-file",
+  "name": "chained-config",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1150,6 +1150,11 @@
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
+    },
+    "class-is": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.0.0.tgz",
+      "integrity": "sha512-zfHWXdTtHqVRar4zdyJe9gsM4eYn0sRVvbHqv751MHC+LD2lrjQdsvOa9E5oYSH3bOWAfXzj1bnqmQbMCMxT0A=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -5828,6 +5833,11 @@
       "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
       "integrity": "sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=",
       "dev": true
+    },
+    "lodash.wrap": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.wrap/-/lodash.wrap-4.1.1.tgz",
+      "integrity": "sha1-nDdwlHqCHsaXipNXHhphea/Nf8g="
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "standard-version": "^4.2.0"
   },
   "dependencies": {
-    "deepmerge": "^2.1.0"
+    "class-is": "^1.0.0",
+    "deepmerge": "^2.1.0",
+    "lodash.wrap": "^4.1.1"
   }
 }

--- a/test/Chainable.spec.js
+++ b/test/Chainable.spec.js
@@ -70,3 +70,26 @@ describe('.when', () => {
         expect(chain).toBe(ret);
     });
 });
+
+describe('.toConfig', () => {
+    it('should throw "not implemented"', () => {
+        const chain = new Chainable();
+
+        expect(() => chain.toConfig()).toThrow('Not implemented');
+    });
+});
+
+describe('#isChainable', () => {
+    it('should return true for chainables', () => {
+        expect(Chainable.isChainable(new Chainable())).toBe(true);
+    });
+
+    it('should return false for non-chainables', () => {
+        expect(Chainable.isChainable({})).toBe(false);
+    });
+
+    it('should return false for undefined/null', () => {
+        expect(Chainable.isChainable(undefined)).toBe(false);
+        expect(Chainable.isChainable(null)).toBe(false);
+    });
+});

--- a/test/ChainedMap.spec.js
+++ b/test/ChainedMap.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { ChainedMap } = require('..');
+const { ChainedMap, ChainedSet } = require('..');
 
 it('should create a chainable object', () => {
     const parent = { foo: 'bar' };
@@ -20,7 +20,23 @@ describe('.set', () => {
         const map = new ChainedMap();
 
         map.set('foo', 'bar');
+
         expect(map.get('foo')).toBe('bar');
+    });
+
+    it('should add a getter/setter if value is a chainable', () => {
+        const map = new ChainedMap();
+        const childMap = new ChainedMap();
+        const otherChildMap = new ChainedMap();
+
+        map.set('foo', childMap);
+
+        expect(map.get('foo')).toBe(childMap);
+        expect(map.foo).toBe(childMap);
+
+        map.foo = otherChildMap;
+
+        expect(map.foo).toBe(otherChildMap);
     });
 
     it('should return itself', () => {
@@ -36,6 +52,7 @@ describe('.get', () => {
         const map = new ChainedMap();
 
         map.set('foo', 'bar');
+
         expect(map.get('foo')).toBe('bar');
     });
 });
@@ -62,7 +79,7 @@ describe('.clear', () => {
 });
 
 describe('.delete', () => {
-    it('should delete an entry', () => {
+    it('should delete an item', () => {
         const map = new ChainedMap();
 
         map.set('foo', 'bar');
@@ -82,7 +99,7 @@ describe('.delete', () => {
 });
 
 describe('.tap', () => {
-    it('should call fn with the entry value and use the return value as the new value', () => {
+    it('should call `fn` with the item value and use the return value as the new value', () => {
         const map = new ChainedMap();
         const fn = jest.fn(() => 'baz');
 
@@ -103,7 +120,7 @@ describe('.tap', () => {
 });
 
 describe('.has', () => {
-    it('should return true if the entry exists', () => {
+    it('should return true if the item exists', () => {
         const map = new ChainedMap();
 
         map.set('foo', 'bar');
@@ -115,7 +132,7 @@ describe('.has', () => {
         expect(map.has('baz')).toBe(true);
     });
 
-    it('should return false if the entry exists', () => {
+    it('should return false if the item exists', () => {
         const map = new ChainedMap();
 
         expect(map.has('foo')).toBe(false);
@@ -123,7 +140,7 @@ describe('.has', () => {
 });
 
 describe('.values', () => {
-    it('should return the entry values by insertion order', () => {
+    it('should return the items\' values', () => {
         const map = new ChainedMap();
 
         map.set('z', 1);
@@ -135,7 +152,7 @@ describe('.values', () => {
 });
 
 describe('.keys', () => {
-    it('should return the entry keys by insertion order', () => {
+    it('should return the item\'s keys', () => {
         const map = new ChainedMap();
 
         map.set('z', 1);
@@ -147,28 +164,23 @@ describe('.keys', () => {
 });
 
 describe('.entries', () => {
-    it('should return an object with the correct keys and values', () => {
+    it('should return an array of key and value pairs', () => {
         const map = new ChainedMap();
 
         map.set('z', 1);
         map.set('a', 2);
         map.set('c', 3);
 
-        const entries = map.entries();
-
-        expect(entries).toEqual({
-            z: 1,
-            a: 2,
-            c: 3,
-        });
-
-        expect(Object.keys(entries)).toEqual(['z', 'a', 'c']);
-        expect(Object.values(entries)).toEqual([1, 2, 3]);
+        expect(map.entries()).toEqual([
+            ['z', 1],
+            ['a', 2],
+            ['c', 3],
+        ]);
     });
 });
 
 describe('.forEach', () => {
-    it('should call fn for each entry', () => {
+    it('should call `fn` for each item', () => {
         const map = new ChainedMap();
 
         map.set('a', 1);
@@ -187,7 +199,7 @@ describe('.forEach', () => {
         ]);
     });
 
-    it('should call fn with the correct `thisArg`', () => {
+    it('should call `fn` with the correct `thisArg`', () => {
         const map = new ChainedMap();
 
         map.set('a', 1);
@@ -220,12 +232,12 @@ describe('.merge', () => {
             d: 4,
         });
 
-        expect(map.entries()).toEqual({
-            a: 1,
-            b: 2,
-            c: 3,
-            d: 4,
-        });
+        expect(map.entries()).toEqual([
+            ['a', 1],
+            ['b', 2],
+            ['c', 3],
+            ['d', 4],
+        ]);
     });
 
     it('should merge and override existing values', () => {
@@ -238,10 +250,10 @@ describe('.merge', () => {
             b: 4,
         });
 
-        expect(map.entries()).toEqual({
-            a: 3,
-            b: 4,
-        });
+        expect(map.entries()).toEqual([
+            ['a', 3],
+            ['b', 4],
+        ]);
     });
 
     it('should merge and keep the order correct', () => {
@@ -266,10 +278,10 @@ describe('.merge', () => {
             a: { foz: 'baz' },
         });
 
-        expect(map.entries()).toEqual({
-            a: { foo: 'bar', foz: 'baz' },
-            b: 2,
-        });
+        expect(map.entries()).toEqual([
+            ['a', { foo: 'bar', foz: 'baz' }],
+            ['b', 2],
+        ]);
     });
 
     it('should omit keys specified in `omit`', () => {
@@ -293,11 +305,11 @@ describe('.merge', () => {
     });
 });
 
-describe('.extend', () => {
-    it('should add methods for the specified shorthands', () => {
+describe('.shorthands', () => {
+    it('should add methods for the specified keys', () => {
         const map = new ChainedMap();
 
-        map.extend(['foo']);
+        map.shorthands(['foo']);
 
         expect(typeof map.foo).toBe('function');
 
@@ -307,8 +319,52 @@ describe('.extend', () => {
 
     it('should return itself', () => {
         const map = new ChainedMap();
-        const ret = map.extend(['foo']);
+        const ret = map.shorthands(['foo']);
 
         expect(map).toBe(ret);
+    });
+});
+
+describe('.toConfig', () => {
+    it('should return an object representation of the config', () => {
+        const map = new ChainedMap();
+        const childMap = new ChainedMap(map);
+        const childSet = new ChainedSet(map);
+
+        childMap.set('foo', 'bar');
+        childSet.add('foz');
+
+        map.set('z', childMap);
+        map.set('a', childSet);
+        map.set('c', 3);
+
+        expect(map.toConfig()).toEqual({
+            z: { foo: 'bar' },
+            a: ['foz'],
+            c: 3,
+        });
+    });
+
+    it('should be sorted by insertion order', () => {
+        const map = new ChainedMap();
+        const childMap = new ChainedMap(map);
+        const childSet = new ChainedSet(map);
+
+        childMap.set('foo', 'bar');
+        childSet.add('foz');
+
+        map.set('z', childMap);
+        map.set('a', childSet);
+        map.set('c', 3);
+
+        expect(Object.keys(map.toConfig())).toEqual(['z', 'a', 'c']);
+    });
+
+    it('should convert to array if `options.asArray` is enabled', () => {
+        const map = new ChainedMap(undefined, { asArray: true });
+
+        map.set('foo', 'bar');
+
+        expect(map.toConfig()).toEqual(['bar']);
     });
 });

--- a/test/ChainedSet.spec.js
+++ b/test/ChainedSet.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { ChainedSet } = require('..');
+const { ChainedSet, ChainedMap } = require('..');
 
 it('should create a chainable object', () => {
     const parent = { foo: 'bar' };
@@ -30,6 +30,7 @@ describe('.add', () => {
 
         set.add('foo');
         set.add('foo');
+
         expect(set.values()).toEqual(['foo']);
     });
 
@@ -55,6 +56,7 @@ describe('.prepend', () => {
 
         set.add('foo');
         set.prepend('foo');
+
         expect(set.values()).toEqual(['foo']);
     });
 
@@ -88,7 +90,7 @@ describe('.clear', () => {
 });
 
 describe('.delete', () => {
-    it('should delete an entry', () => {
+    it('should delete an item', () => {
         const set = new ChainedSet();
 
         set.add('foo');
@@ -108,7 +110,7 @@ describe('.delete', () => {
 });
 
 describe('.has', () => {
-    it('should return true if the entry exists', () => {
+    it('should return true if the item exists', () => {
         const set = new ChainedSet();
 
         set.add('foo');
@@ -119,7 +121,7 @@ describe('.has', () => {
         expect(set.has('baz')).toBe(false);
     });
 
-    it('should return false if the entry exists', () => {
+    it('should return false if the item exists', () => {
         const set = new ChainedSet();
 
         expect(set.has('foo')).toBe(false);
@@ -127,7 +129,7 @@ describe('.has', () => {
 });
 
 describe('.values', () => {
-    it('should return the entry values by insertion order', () => {
+    it('should return the items\' values by insertion order', () => {
         const set = new ChainedSet();
 
         set.add('z');
@@ -139,7 +141,7 @@ describe('.values', () => {
 });
 
 describe('.forEach', () => {
-    it('should call fn for each value', () => {
+    it('should call `fn` for each value', () => {
         const set = new ChainedSet();
 
         set.add('a');
@@ -158,7 +160,7 @@ describe('.forEach', () => {
         ]);
     });
 
-    it('should call fn with the correct `thisArg`', () => {
+    it('should call `fn` with the correct `thisArg`', () => {
         const set = new ChainedSet();
 
         set.add('a');
@@ -206,5 +208,26 @@ describe('.merge', () => {
         const ret = set.merge(['foo']);
 
         expect(set).toBe(ret);
+    });
+});
+
+describe('.toConfig', () => {
+    it('should return an array representation of the config', () => {
+        const set = new ChainedSet();
+        const childMap = new ChainedMap(set);
+        const childSet = new ChainedSet(set);
+
+        childMap.set('foo', 'bar');
+        childSet.add('foz');
+
+        set.add(childMap);
+        set.add(childSet);
+        set.add('c');
+
+        expect(set.toConfig()).toEqual([
+            { foo: 'bar' },
+            ['foz'],
+            'c',
+        ]);
     });
 });

--- a/test/OrderableChainedMap.spec.js
+++ b/test/OrderableChainedMap.spec.js
@@ -29,7 +29,7 @@ describe('.set', () => {
 });
 
 describe('.delete', () => {
-    it('should delete the entry from the order store', () => {
+    it('should delete the item from the order store', () => {
         const map = new OrderableChainedMap();
 
         map.move('foo', ({ before }) => before('bar'));
@@ -89,7 +89,7 @@ describe('.order', () => {
 });
 
 describe('.values', () => {
-    it('should return the entry values by insertion order', () => {
+    it('should be sorted by the correct order', () => {
         const map = new OrderableChainedMap();
 
         map.set('prop1', 1);
@@ -117,7 +117,7 @@ describe('.values', () => {
 });
 
 describe('.keys', () => {
-    it('should return the entry keys by the correct order', () => {
+    it('should be sorted by the correct order', () => {
         const map = new OrderableChainedMap();
 
         map.set('prop1', 1);
@@ -145,7 +145,7 @@ describe('.keys', () => {
 });
 
 describe('.entries', () => {
-    it('should return an object with keys and values by the correct order', () => {
+    it('should be sorted by the correct order', () => {
         const map = new OrderableChainedMap();
 
         map.set('prop1', 1);
@@ -155,9 +155,11 @@ describe('.entries', () => {
         map.move('prop1', ({ after }) => after('prop3'));
         map.move('prop2', ({ before }) => before('prop1'));
 
-        const entries = map.entries();
-
-        expect(Object.keys(entries)).toEqual(['prop3', 'prop2', 'prop1']);
+        expect(map.entries()).toEqual([
+            ['prop3', 3],
+            ['prop2', 2],
+            ['prop1', 1],
+        ]);
     });
 
     it('should deal with relative keys that does not exist', () => {
@@ -170,14 +172,16 @@ describe('.entries', () => {
         map.move('prop1', ({ after }) => after('prop4'));
         map.move('prop2', ({ before }) => before('prop5'));
 
-        const entries = map.entries();
-
-        expect(Object.keys(entries)).toEqual(['prop1', 'prop2', 'prop3']);
+        expect(map.entries()).toEqual([
+            ['prop1', 1],
+            ['prop2', 2],
+            ['prop3', 3],
+        ]);
     });
 });
 
 describe('.forEach', () => {
-    it('should call fn for each entry by the correct order', () => {
+    it('should call `fn` by the correct order', () => {
         const map = new OrderableChainedMap();
 
         map.set('prop1', 1);
@@ -219,5 +223,46 @@ describe('.forEach', () => {
             [2, 'prop2', map],
             [3, 'prop3', map],
         ]);
+    });
+});
+
+describe('.toConfig', () => {
+    it('should be sorted by the correct order', () => {
+        const map = new OrderableChainedMap();
+
+        map.set('prop1', 1);
+        map.set('prop2', 2);
+        map.set('prop3', 3);
+
+        map.move('prop1', ({ after }) => after('prop3'));
+        map.move('prop2', ({ before }) => before('prop1'));
+
+        expect(Object.keys(map.toConfig())).toEqual(['prop3', 'prop2', 'prop1']);
+    });
+
+    it('should return an array sorted by the correct order if `options.asArray` is enabled', () => {
+        const map = new OrderableChainedMap(undefined, { asArray: true });
+
+        map.set('prop1', 1);
+        map.set('prop2', 2);
+        map.set('prop3', 3);
+
+        map.move('prop1', ({ after }) => after('prop3'));
+        map.move('prop2', ({ before }) => before('prop1'));
+
+        expect(map.toConfig()).toEqual([3, 2, 1]);
+    });
+
+    it('should deal with relative keys that does not exist', () => {
+        const map = new OrderableChainedMap();
+
+        map.set('prop1', 1);
+        map.set('prop2', 2);
+        map.set('prop3', 3);
+
+        map.move('prop1', ({ after }) => after('prop4'));
+        map.move('prop2', ({ before }) => before('prop5'));
+
+        expect(Object.keys(map.toConfig())).toEqual(['prop1', 'prop2', 'prop3']);
     });
 });


### PR DESCRIPTION
The `toConfig` feature require some rethougts on some things:

- Ideally, `toConfig` wouldn't need to be re-implemented everytime a chain has child chains
- Because of that, `set` was changed to add a getter/setter if value is a chainable
- To make things more consistent, `extend` was renamed to `shorthands`
- Additionally, to be closer to the native Map, `entries` was changed to return an array of key value pairs
- Added `asArray` option to ChainedMap and OrderedChainedMap

Closes #2.
